### PR TITLE
Example permission to support auto help and essentials per user help.

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -5,6 +5,7 @@ commands:
     modreq:
         description: Request help from a moderator
         usage: /<command> [message]
+        permission: modtrs.command.modreq
     check:
         description: List all the currently open requests. Use p:# to go to a page, and t:open/t:all to change the type of the request
         usage: /<command> [p:#] [t:open|all]


### PR DESCRIPTION
The rest of the permissions could be filled out like this to support /help
