### PR TITLE
Update ModTRS for 1.1-R5-SNAPSHOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Eclipse stuff
+/.classpath
+/.project
+/.settings
+
+# netbeans
+/nbproject
+
+# maven
+/target
+
+# vim
+.*.sw[a-p]
+
+# misc
+*~

--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,12 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>1.1-R4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.sk89q</groupId>
             <artifactId>dummypermscompat</artifactId>
-            <version>1.2</version>
+            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>javax.persistence</groupId>
@@ -40,7 +40,7 @@
         </dependency>
     </dependencies>
     <build>
-        <finalName>ModTRS</finalName>
+        <finalName>${project.name}</finalName>
         <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
         <defaultGoal>clean install</defaultGoal>
         <plugins>
@@ -108,13 +108,7 @@
     <repositories>
         <repository>
             <id>bukkit-repo</id>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <url>http://repo.bukkit.org/artifactory/repo</url>
+            <url>http://repo.bukkit.org/content/groups/public</url>
         </repository>
         <repository>
             <id>sk89q-mvn2</id>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.1-R4-SNAPSHOT</version>
+            <version>1.1-R5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.sk89q</groupId>
@@ -91,16 +91,7 @@
                 <filtering>true</filtering>
                 <directory>${basedir}/src/main/resources/</directory>
                 <includes>
-                    <include>plugin.yml</include>
-                </includes>
-            </resource>
-            <resource>
-                <targetPath>defaults/</targetPath>
-                <filtering>true</filtering>
-                <directory>${basedir}/src/main/resources/</directory>
-                <includes>
-                    <include>config.yml</include>
-                    <include>messages.yml</include>
+                    <include>*.yml</include>
                 </includes>
             </resource>
         </resources>

--- a/src/main/java/yetanotherx/bukkitplugin/ModTRS/ModTRS.java
+++ b/src/main/java/yetanotherx/bukkitplugin/ModTRS/ModTRS.java
@@ -84,7 +84,7 @@ public class ModTRS extends JavaPlugin {
             this.commandHandler = CommandHandler.load(this);
             this.api = ModTRSAPI.load(this);
             
-            this.getServer().getPluginManager().registerEvent( Event.Type.PLAYER_JOIN, this.listener, Event.Priority.Monitor, this );
+            this.getServer().getPluginManager().registerEvents(this.listener, this);
 
             log.info("Plugin enabled! (version " + this.getDescription().getVersion() + ")");
             log.debug("Debug mode enabled!");

--- a/src/main/java/yetanotherx/bukkitplugin/ModTRS/command/ModlistCommand.java
+++ b/src/main/java/yetanotherx/bukkitplugin/ModTRS/command/ModlistCommand.java
@@ -41,6 +41,11 @@ public class ModlistCommand implements CommandExecutor {
         String mods = "";
 
         for (Player user : players) {
+            // Skip invisible mods
+            if (sender instanceof Player && !((Player)sender).canSee(user)) {
+                continue;
+            }
+
             if (ModTRSPermissions.has(user, "modtrs.mod")) {
                 mods = mods + user.getName() + ", ";
             }

--- a/src/main/java/yetanotherx/bukkitplugin/ModTRS/listener/ModTRSListener.java
+++ b/src/main/java/yetanotherx/bukkitplugin/ModTRS/listener/ModTRSListener.java
@@ -3,7 +3,9 @@ package yetanotherx.bukkitplugin.ModTRS.listener;
 import java.util.List;
 import org.bukkit.ChatColor;
 import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerListener;
+import org.bukkit.event.Listener;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 
 import yetanotherx.bukkitplugin.ModTRS.ModTRS;
 import yetanotherx.bukkitplugin.ModTRS.model.ModTRSRequest;
@@ -11,7 +13,7 @@ import yetanotherx.bukkitplugin.ModTRS.util.Message;
 import yetanotherx.bukkitplugin.ModTRS.command.ModTRSCommandSender;
 import yetanotherx.bukkitplugin.ModTRS.util.ModTRSSettings;
 
-public class ModTRSListener extends PlayerListener {
+public class ModTRSListener implements Listener {
 
     private ModTRS parent;
 
@@ -22,7 +24,7 @@ public class ModTRSListener extends PlayerListener {
     /**
      * Simply notifies a user that there are open requests when they join
      */
-    @Override
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerJoin(PlayerJoinEvent event) {
 
         ModTRSCommandSender player = new ModTRSCommandSender(event.getPlayer());

--- a/src/main/java/yetanotherx/bukkitplugin/ModTRS/util/ModTRSFunctions.java
+++ b/src/main/java/yetanotherx/bukkitplugin/ModTRS/util/ModTRSFunctions.java
@@ -25,7 +25,9 @@ public class ModTRSFunctions {
      * Returns true if a user is online
      */
     public static boolean isUserOnline( String username, Server server ) {
-	return server.getPlayer(username).isOnline();
+	Player player = server.getPlayer(username);
+	if(player == null) return false;
+	return player.isOnline();
     }
     
     /**

--- a/src/main/java/yetanotherx/bukkitplugin/ModTRS/util/ModTRSSettings.java
+++ b/src/main/java/yetanotherx/bukkitplugin/ModTRS/util/ModTRSSettings.java
@@ -31,11 +31,11 @@ public class ModTRSSettings {
      */
     public static void load(ModTRS parent) {
 
-        File dataDirectory = new File("plugins" + File.separator + "ModTRS" + File.separator);
+        File dataDirectory = parent.getDataFolder();
 
         dataDirectory.mkdirs();
 
-        File file = new File("plugins" + File.separator + "ModTRS", "config.yml");
+        File file = new File(dataDirectory, "config.yml");
 
         ModTRS.log.debug("Loading config file: " + file.getPath());
 
@@ -101,7 +101,7 @@ public class ModTRSSettings {
     }
 
     public static void saveConfigFromResource(File file) {
-        InputStream input = ModTRS.class.getResourceAsStream("/defaults/config.yml");
+        InputStream input = ModTRS.class.getResourceAsStream("config.yml");
         if (input != null) {
             FileOutputStream output = null;
 


### PR DESCRIPTION
The new developer version of CraftBukkit (1.1-R5-SNAPSHOT) removed some deprecated stuff and broke ModTRS. This fixes that, and also fixes some minor issues I'd run into.
